### PR TITLE
Add sample WhatsApp Flow for food ordering

### DIFF
--- a/examples/food-order-flow.json
+++ b/examples/food-order-flow.json
@@ -1,0 +1,57 @@
+{
+	"name": "food_order_flow",
+	"entry_screen": "menu",
+	"screens": [
+		{
+			"id": "menu",
+			"title": "Select a menu item",
+			"components": [
+				{
+					"type": "single-select",
+					"id": "item",
+					"label": "What would you like to eat?",
+					"required": true,
+					"options": [
+						{ "id": "margherita_pizza", "title": "Margherita Pizza" },
+						{ "id": "veggie_burger", "title": "Veggie Burger" },
+						{ "id": "pasta_alfredo", "title": "Pasta Alfredo" },
+						{ "id": "caesar_salad", "title": "Caesar Salad" },
+						{ "id": "sushi_roll", "title": "Sushi Roll" }
+					]
+				}
+			],
+			"next": "quantity"
+		},
+		{
+			"id": "quantity",
+			"title": "Quantity",
+			"components": [
+				{
+					"type": "text",
+					"id": "qty",
+					"label": "How many servings?",
+					"input_type": "number",
+					"required": true
+				}
+			],
+			"next": "confirm"
+		},
+		{
+			"id": "confirm",
+			"title": "Confirm order",
+			"components": [
+				{
+					"type": "summary",
+					"id": "summary",
+					"text": "Order: {{item}} x {{qty}}"
+				}
+			],
+			"actions": [
+				{
+					"type": "submit",
+					"label": "Place Order"
+				}
+			]
+		}
+	]
+}

--- a/examples/food-order-start-message.json
+++ b/examples/food-order-start-message.json
@@ -1,0 +1,22 @@
+{
+	"messaging_product": "whatsapp",
+	"to": "<PHONE_NUMBER>",
+	"type": "interactive",
+	"interactive": {
+		"type": "flow",
+		"header": {
+			"type": "text",
+			"text": "Food Order"
+		},
+		"body": {
+			"text": "Tap to place your food order"
+		},
+		"action": {
+			"name": "food_order_flow",
+			"parameters": {
+				"version": "1.0",
+				"button_text": "Start Order"
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add flow definition for food order via WhatsApp Flow
- include message payload to launch the flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45f5f7ba0832a8645d42c4477d1f3